### PR TITLE
Update sample_management.ipynb

### DIFF
--- a/Spectra Analyze/sample_management.ipynb
+++ b/Spectra Analyze/sample_management.ipynb
@@ -143,7 +143,6 @@
     "    custom_filename=\"Dangerous_file\",\n",
     "    tags=\"dangerous,malware,tuesday\",\n",
     "    comment=\"Uploaded from the replacement disk\",\n",
-    "    rl_cloud_sandbox_platform=\"windows10\"\n",
     ")\n",
     "\n",
     "print(response.text)"

--- a/Spectra Analyze/sample_management.ipynb
+++ b/Spectra Analyze/sample_management.ipynb
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = a1000.upload_sample_from_path(\n",
+    "response = a1000.submit_file_from_path(\n",
     "    file_path=\"our_local_file.exe\",\n",
     "    custom_filename=\"Dangerous_file\",\n",
     "    tags=\"dangerous,malware,tuesday\",\n",


### PR DESCRIPTION
This PR updates the documentation in the Spectra Analyze section to replace a reference to a non-existing method for file upload.

**Changes**:
Replaced outdated/non-existent method name `upload_sample_from_path` with the correct one `submit_file_from_path` in the Spectra Analyze section.

**Reason**:
The previous method name was invalid and could cause confusion for users following the documentation.

**Impact**:
Documentation improvement only — no code changes or functional impact.

